### PR TITLE
39_criar_CRUD_endereco_do_colaborador

### DIFF
--- a/src/@types/dto/ColaboradorDto.ts
+++ b/src/@types/dto/ColaboradorDto.ts
@@ -1,6 +1,17 @@
+import { EnderecoDto } from "./EnderecoDto";
+
 export type ColaboradorDto = {
   nome: string;
   email: string;
   telefone: string;
   dataInicio: Date;
+  endereco: EnderecoDto;
+};
+
+export type AlteraColaboradorDto = {
+  nome?: string;
+  email?: string;
+  telefone?: string;
+  dataInicio?: Date;
+  endereco?: EnderecoDto;
 };

--- a/src/@types/repositories/IColaboradorRepository.ts
+++ b/src/@types/repositories/IColaboradorRepository.ts
@@ -2,8 +2,7 @@ import { Colaborador } from "models/ColaboradorEntity";
 
 export interface IColaboradorRepository {
   save(colaborador: Colaborador): Promise<Colaborador>;
-  findByEmail(email: string): Promise<Colaborador>;
-  find(): Promise<Colaborador[]>;
-  findOne(id: number): Promise<Colaborador>;
+  findById(id: number): Promise<Colaborador>;
+  findAll(): Promise<Colaborador[]>;
   remove(entities0: Colaborador | Colaborador[]): Promise<Colaborador[]>;
 }

--- a/src/@types/services/IColaboradorService.ts
+++ b/src/@types/services/IColaboradorService.ts
@@ -1,10 +1,13 @@
 import { Colaborador } from "../../models/ColaboradorEntity";
-import { ColaboradorDto } from "../dto/ColaboradorDto";
+import { AlteraColaboradorDto, ColaboradorDto } from "../dto/ColaboradorDto";
 
 export interface IColaboradorService {
   listar(): Promise<Colaborador[]>;
   buscar(id: number): Promise<Colaborador>;
   criar(colaboradorDto: ColaboradorDto): Promise<Colaborador>;
-  atualizar(id: number, colaboradorDto: ColaboradorDto): Promise<void>;
+  atualizar(
+    id: number,
+    colaboradorDtoAtualizado: AlteraColaboradorDto
+  ): Promise<void>;
   remover(id: number): Promise<void>;
 }

--- a/src/repositories/ColaboradorRepository.ts
+++ b/src/repositories/ColaboradorRepository.ts
@@ -7,12 +7,17 @@ export class ColaboradorRepository
   extends Repository<Colaborador>
   implements IColaboradorRepository
 {
-  findByEmail(emailColaborador: "string"): Promise<Colaborador> {
+  findById(usuarioId: number): Promise<Colaborador> {
     return this.findOne({
-      relations: ["equipamentos"],
+      relations: ["endereco"],
       where: {
-        email: emailColaborador,
+        id: usuarioId,
       },
+    });
+  }
+  findAll(): Promise<Colaborador[]> {
+    return this.find({
+      relations: ["endereco"],
     });
   }
 }

--- a/src/services/ColaboradorService.ts
+++ b/src/services/ColaboradorService.ts
@@ -2,7 +2,10 @@ import { IColaboradorRepository } from "../@types/repositories/IColaboradorRepos
 import { IColaboradorService } from "../@types/services/IColaboradorService";
 import { Inject, Service } from "typedi";
 import { Colaborador } from "../models/ColaboradorEntity";
-import { ColaboradorDto } from "../@types/dto/ColaboradorDto";
+import {
+  AlteraColaboradorDto,
+  ColaboradorDto,
+} from "../@types/dto/ColaboradorDto";
 import { colaboradorFactory } from "../dataMappers/colaboradorFactory";
 import { ColaboradorNaoExiste } from "../@types/errors/ColaboradorNaoExiste";
 
@@ -22,9 +25,15 @@ export class ColaboradorService implements IColaboradorService {
     const novoColaborador = colaboradorFactory(colaboradorDto);
     return await this.colaboradorRepository.save(novoColaborador);
   }
-  async atualizar(id: number, colaboradorDto: ColaboradorDto): Promise<void> {
+  async atualizar(
+    id: number,
+    colaboradorDtoAtualizado: AlteraColaboradorDto
+  ): Promise<void> {
     const colaborador = await this.checaColaborador(id);
-    const colaboradorAtualizado = { ...colaborador, ...colaboradorDto };
+    const colaboradorAtualizado = {
+      ...colaborador,
+      ...colaboradorDtoAtualizado,
+    };
     await this.colaboradorRepository.save(colaboradorAtualizado);
     return;
   }


### PR DESCRIPTION
Pessoal, conforme conversamos ontem. Não via necessidade de criar mais metodos no service ou criar um repo. No entanto, fiz algumas alterações no colaborador para que possamos utiliza-lo junto com o endereço. 

- metodos no repo para retornar colaborador com endereço
- type novo: alteraColaboradorDto para atualizaçao do colaborador 
- type colaboradorDto: agora com propriedade de endereco.